### PR TITLE
Fix cross-thread CAT commands

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # FT897
+
+Simple PyQt5 utility for controlling the Yaesu FT‑897 transceiver over
+its CAT interface.  The code is organised into several small modules:
+
+* `cat_control.py` – serial I/O and CAT command helpers
+* `meters.py` – formatting utilities for S‑meter and power readings
+* `resources.py` – shared constants such as mode codes and band lists
+* `ui_main.py` – PyQt5 user interface
+* `main.py` – application entry point
+* `debug_power.py` – optional helper for logging raw CAT traffic
+* `log_window.py` – dialog window for saving meter changes to a text file
+* `meter_validator.py` – interactive script to compare observed meter
+  readings with CAT responses
+
+## Installation
+
+Install the dependencies listed in ``requirements.txt`` using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+The UI polls the radio every 400 ms for the current frequency and only
+queries meter values about once per second or when the frequency changes.
+Meter data are read using the `0xE7` command which returns a five-byte block containing the S-meter and TX power values.
+Power menus are populated dynamically based on the selected band.  Run the
+application with `--debug` to print all bytes exchanged with the radio.  You
+can optionally pass `--port` and `--baud` to open the serial connection
+automatically.
+The connection uses standard **8N1** framing; adjust the radio's menu settings
+if needed.
+Use the **Log** menu to open a window that records meter and power
+changes to a chosen file for later analysis.  The helper script
+`meter_validator.py` can be used to compare observed front-panel
+readings with the CAT responses for troubleshooting.
+
+This project is released under the MIT license.  See ``LICENSE`` for details.
+
+
+## Tests
+Install the dependencies and run the tests using:
+
+```bash
+pip install -r requirements.txt
+python3 -m py_compile *.py tests/*.py
+pytest -q
+```

--- a/cat_control.py
+++ b/cat_control.py
@@ -1,0 +1,389 @@
+"""Serial CAT control for the Yaesu FT-897."""
+
+import threading
+import time
+from typing import Optional, Tuple
+from PyQt5.QtCore import QThread, pyqtSignal, QTimer, pyqtSlot
+
+import sys
+
+import serial
+
+
+class FT897CAT:
+    """Minimal CAT control helper."""
+
+    def __init__(self, debug: bool = False):
+        self.serial_port: Optional[serial.Serial] = None
+        self.is_connected = False
+        self._lock = threading.Lock()
+        self.ptt_active = False
+        self.debug = debug
+
+    def _log(self, direction: str, data: bytes) -> None:
+        """Print raw communication bytes when debugging is enabled."""
+        if self.debug:
+            hex_str = " ".join(f"{b:02X}" for b in data)
+            print(f"{direction} {hex_str}")
+
+    def connect(self, port: str, baudrate: int = 9600) -> bool:
+        try:
+            self.serial_port = serial.Serial(
+                port=port,
+                baudrate=baudrate,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                # use one stop bit for compatibility with common CAT settings
+                stopbits=serial.STOPBITS_ONE,
+                timeout=0.1,
+                write_timeout=0.1,
+            )
+            self.is_connected = True
+            return True
+        except Exception as exc:
+            print(f"Connect error: {exc}")
+            return False
+
+    def disconnect(self) -> None:
+        if self.serial_port and self.serial_port.is_open:
+            self.serial_port.close()
+        self.is_connected = False
+
+    def _send(self, data: bytes) -> bool:
+        """Write raw bytes to the serial port in a thread-safe way."""
+        if not self.serial_port:
+            return False
+        try:
+            # hold the lock only for the write operation
+            with self._lock:
+                self._log('>>', data)
+                self.serial_port.write(data)
+            # flush outside the lock so other threads are not blocked
+            self.serial_port.flush()
+        except Exception as exc:
+            print(f"Write error: {exc}")
+            return False
+        return True
+
+    def _read(self, length: int = 5) -> Optional[bytes]:
+        """Read up to ``length`` bytes with simple retry to gather full data."""
+        if not self.serial_port:
+            return None
+        timeout = self.serial_port.timeout or 0.2
+        end = time.time() + timeout * max(1, length)
+        data = bytearray()
+        while len(data) < length and time.time() < end:
+            try:
+                chunk = self.serial_port.read(length - len(data))
+            except Exception as exc:
+                print(f"Read error: {exc}")
+                return None
+            if chunk:
+                data.extend(chunk)
+            else:
+                # small wait to avoid busy loop if no data arrives
+                time.sleep(timeout / 2)
+        if data:
+            self._log('<<', bytes(data))
+        return bytes(data) if data else None
+
+    def get_frequency_and_mode(self) -> Tuple[Optional[int], Optional[int]]:
+        if not self._send(b"\x00\x00\x00\x00\x03"):
+            return None, None
+        resp = self._read(5)
+        if not resp or len(resp) != 5:
+            return None, None
+        units_10hz = 0
+        for b in resp[:4]:
+            units_10hz = units_10hz * 100 + ((b >> 4) & 0x0F) * 10 + (b & 0x0F)
+        return units_10hz * 10, resp[4]
+
+    def set_frequency(self, freq_hz: int) -> bool:
+        units = freq_hz // 10
+        digits = []
+        for _ in range(8):
+            digits.insert(0, units % 10)
+            units //= 10
+        bcd = bytes(((digits[i] << 4) | digits[i + 1]) for i in range(0, 8, 2))
+        return self._send(bcd + b"\x01")
+
+    def set_mode(self, mode_code: int) -> bool:
+        cmd = bytes([mode_code, 0x00, 0x00, 0x00, 0x07])
+        return self._send(cmd)
+
+    def toggle_vfo(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x81")
+
+    def split_on(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x02")
+
+    def split_off(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x82")
+
+    def clarifier_on(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x05")
+
+    def clarifier_off(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x85")
+
+    def repeater_plus(self) -> bool:
+        return self._send(b"\x49\x09")
+
+    def repeater_minus(self) -> bool:
+        return self._send(b"\x89\x09")
+
+
+    def set_power(self, watts: int, band_label: str) -> bool:
+        if band_label in {
+            "160 m",
+            "80 m",
+            "60 m",
+            "40 m",
+            "30 m",
+            "20 m",
+            "17 m",
+            "15 m",
+            "12 m",
+            "10 m",
+        }:
+            addr, min_raw, max_raw = 0x9B, 0x05, 0x64
+        elif band_label == "6 m":
+            addr, min_raw, max_raw = 0xAA, 0x05, 0x64
+        elif band_label == "2 m":
+            addr, min_raw, max_raw = 0xAB, 0x05, 0x32
+        elif band_label == "70 cm":
+            addr, min_raw, max_raw = 0xAC, 0x02, 0x14
+        else:
+            return False
+        raw = max(min_raw, min(max_raw, watts))
+        # opcode 0x79 writes menu parameters without altering frequency
+        cmd = bytes([0x00, addr, raw, 0x00, 0x79])
+        return self._send(cmd)
+
+    def ptt_on(self) -> bool:
+        success = self._send(b"\x00\x00\x00\x00\x08")
+        if success:
+            self.ptt_active = True
+        return success
+
+    def ptt_off(self) -> bool:
+        success = self._send(b"\x00\x00\x00\x00\x88")
+        if success:
+            self.ptt_active = False
+        return success
+
+    # ---------------- Additional CAT commands from user list -----------------
+    def get_smeter_alt(self) -> Optional[int]:
+        """Alternative S-meter read using opcode 0x0F subcommand 0x02."""
+        if not self._send(b"\x02\x00\x00\x00\x0F"):
+            return None
+        resp = self._read(2)
+        if not resp or len(resp) < 2:
+            return None
+        return resp[1]
+
+    def get_meter_block(self) -> Optional[bytes]:
+        """Read the five-byte meter block using opcode ``0xE7``.
+
+        Some radios echo the command or prepend address bytes before the
+        actual meter values. To handle both cases we read up to 11 bytes
+        and return the last five, which correspond to ``S`` meter, ``ALC``,
+        ``SWR``, ``FM deviation`` and ``supply voltage``.
+        """
+        if not self._send(b"\x00\x00\x00\x00\xE7"):
+            return None
+        resp = self._read(11)  # enough for possible echoes/prefixes
+        if not resp or len(resp) < 5:
+            return None
+        return resp[-5:]
+
+    def get_s_and_power(self) -> Tuple[Optional[int], Optional[int]]:
+        """Return S-meter and power meter values using the 0xE7 meter block."""
+        block = self.get_meter_block()
+        if not block or len(block) < 2:
+            return None, None
+        s_val = block[0]
+        # According to the user-supplied tables, TX power corresponds to byte 1
+        p_val = block[1]
+        return s_val, p_val
+
+    def get_full_status(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
+        """Return frequency, mode, S-meter and power in one round trip."""
+        cmds = (
+            b"\x00\x00\x00\x00\x03"  # read frequency/mode
+            b"\x00\x00\x00\x00\xE7"  # read S-meter
+            b"\x00\x00\x00\x00\xF7"  # read power meter
+        )
+        if not self._send(cmds):
+            return None, None, None, None
+        resp = self._read(12)
+        if not resp or len(resp) < 12:
+            return None, None, None, None
+
+        freq_bytes = resp[0:5]
+        units_10hz = 0
+        for b in freq_bytes[:4]:
+            units_10hz = units_10hz * 100 + ((b >> 4) & 0x0F) * 10 + (b & 0x0F)
+        freq_hz = units_10hz * 10
+        mode = freq_bytes[4]
+
+        s_val = resp[5]
+        p_val = resp[11]
+        return freq_hz, mode, s_val, p_val
+
+    def get_voltage(self) -> Optional[int]:
+        """Read supply voltage (opcode 0x1C)."""
+        if not self._send(b"\x00\x00\x00\x00\x1C"):
+            return None
+        resp = self._read(2)
+        if not resp or len(resp) < 2:
+            return None
+        return resp[1]
+
+    def power_off(self) -> bool:
+        """Turn the transceiver off using opcode 0x1F."""
+        return self._send(b"\x00\x00\x00\x00\x1F")
+
+    def sql_on(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x10")
+
+    def sql_off(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x90")
+
+    def lock_on(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x11")
+
+    def lock_off(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x91")
+
+    def vox_on(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x12")
+
+    def vox_off(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x92")
+
+    def tuner_toggle(self) -> bool:
+        return self._send(b"\x00\x00\x00\x00\x14")
+
+
+class SerialWorker(QThread):
+    """Background thread for polling CAT data and handling commands."""
+
+    status = pyqtSignal(int, int, int, int)
+    connected = pyqtSignal(bool)
+    # command requests from the GUI thread
+    set_frequency_req = pyqtSignal(int)
+    set_mode_req = pyqtSignal(int)
+    set_power_req = pyqtSignal(str, int)
+    ptt_on_req = pyqtSignal()
+    ptt_off_req = pyqtSignal()
+    toggle_vfo_req = pyqtSignal()
+    split_on_req = pyqtSignal()
+    split_off_req = pyqtSignal()
+    clar_on_req = pyqtSignal()
+    clar_off_req = pyqtSignal()
+    rpt_plus_req = pyqtSignal()
+    rpt_minus_req = pyqtSignal()
+
+    def __init__(self, port: str, baudrate: int = 9600, debug: bool = False):
+        super().__init__()
+        self.cat = FT897CAT(debug=debug)
+        self.port = port
+        self.baudrate = baudrate
+        self._poll_timer: QTimer | None = None
+        self._last_freq: int | None = None
+        self._last_meter_time = 0.0
+
+        # forward GUI requests to slot methods within this thread
+        self.set_frequency_req.connect(self.set_frequency)
+        self.set_mode_req.connect(self.set_mode)
+        self.set_power_req.connect(self.set_power)
+        self.ptt_on_req.connect(self.ptt_on)
+        self.ptt_off_req.connect(self.ptt_off)
+        self.toggle_vfo_req.connect(self.toggle_vfo)
+        self.split_on_req.connect(self.split_on)
+        self.split_off_req.connect(self.split_off)
+        self.clar_on_req.connect(self.clarifier_on)
+        self.clar_off_req.connect(self.clarifier_off)
+        self.rpt_plus_req.connect(self.repeater_plus)
+        self.rpt_minus_req.connect(self.repeater_minus)
+
+    def run(self) -> None:
+        ok = self.cat.connect(self.port, baudrate=self.baudrate)
+        self.connected.emit(ok)
+        if not ok:
+            return
+        self._poll_timer = QTimer()
+        self._poll_timer.setInterval(400)
+        self._poll_timer.timeout.connect(self.poll)
+        self._poll_timer.start()
+        self.exec_()
+        if self._poll_timer is not None:
+            self._poll_timer.stop()
+        self.cat.disconnect()
+
+    def stop(self) -> None:
+        self.quit()
+        self.wait()
+
+    @pyqtSlot(int)
+    def set_frequency(self, freq_hz: int) -> None:
+        self.cat.set_frequency(freq_hz)
+
+    @pyqtSlot(int)
+    def set_mode(self, mode_code: int) -> None:
+        self.cat.set_mode(mode_code)
+
+    @pyqtSlot(str, int)
+    def set_power(self, band_label: str, watts: int) -> None:
+        self.cat.set_power(watts, band_label)
+
+    @pyqtSlot()
+    def ptt_on(self) -> None:
+        self.cat.ptt_on()
+
+    @pyqtSlot()
+    def ptt_off(self) -> None:
+        self.cat.ptt_off()
+
+    @pyqtSlot()
+    def toggle_vfo(self):
+        self.cat.toggle_vfo()
+
+    @pyqtSlot()
+    def split_on(self):
+        self.cat.split_on()
+
+    @pyqtSlot()
+    def split_off(self):
+        self.cat.split_off()
+
+    @pyqtSlot()
+    def clarifier_on(self):
+        self.cat.clarifier_on()
+
+    @pyqtSlot()
+    def clarifier_off(self):
+        self.cat.clarifier_off()
+
+    @pyqtSlot()
+    def repeater_plus(self):
+        self.cat.repeater_plus()
+
+    @pyqtSlot()
+    def repeater_minus(self):
+        self.cat.repeater_minus()
+
+    def poll(self) -> None:
+        freq, mode = self.cat.get_frequency_and_mode()
+        if freq is None or mode is None:
+            return
+        sm = pw = 0
+        now = time.time()
+        if freq != self._last_freq or now - self._last_meter_time > 1.0:
+            self._last_freq = freq
+            self._last_meter_time = now
+            sm, pw = self.cat.get_meters()
+            sm = sm or 0
+            pw = pw or 0
+        self.status.emit(freq, mode, sm, pw)

--- a/debug_power.py
+++ b/debug_power.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Simple tool to log CAT traffic while polling power settings."""
+
+import sys
+import time
+from cat_control import FT897CAT
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: debug_power.py <serial-port> [baudrate]")
+        return
+    port = sys.argv[1]
+    baud = int(sys.argv[2]) if len(sys.argv) > 2 else 9600
+    cat = FT897CAT(debug=True)
+    if not cat.connect(port, baudrate=baud):
+        print("Cannot connect to", port)
+        return
+    print("Connected. Press Ctrl-C to stop.")
+    try:
+        while True:
+            block = cat.get_meter_block()
+            if block is not None:
+                hex_block = " ".join(f"{b:02X}" for b in block)
+                print("Meter block:", hex_block)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        cat.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/log_window.py
+++ b/log_window.py
@@ -1,0 +1,94 @@
+from PyQt5.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLineEdit,
+    QLabel, QFileDialog, QTextEdit, QMessageBox
+)
+import time
+
+
+class LogWindow(QDialog):
+    """Simple dialog for logging meter changes to a text file."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Logování")
+        self._file = None
+
+        layout = QVBoxLayout(self)
+
+        file_layout = QHBoxLayout()
+        file_layout.addWidget(QLabel("Soubor:"))
+        self.path_edit = QLineEdit()
+        file_layout.addWidget(self.path_edit)
+        browse = QPushButton("Vybrat…")
+        browse.clicked.connect(self.choose_file)
+        file_layout.addWidget(browse)
+        layout.addLayout(file_layout)
+
+        btn_layout = QHBoxLayout()
+        self.start_btn = QPushButton("Start")
+        self.start_btn.clicked.connect(self.start_logging)
+        btn_layout.addWidget(self.start_btn)
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self.stop_logging)
+        btn_layout.addWidget(self.stop_btn)
+        layout.addLayout(btn_layout)
+
+        self.log_view = QTextEdit()
+        self.log_view.setReadOnly(True)
+        layout.addWidget(self.log_view)
+
+    def choose_file(self):
+        path, _ = QFileDialog.getSaveFileName(self, "Vyberte soubor logu", "log.txt", "Text files (*.txt);;All files (*)")
+        if path:
+            self.path_edit.setText(path)
+
+    def start_logging(self):
+        if self._file:
+            return
+        path = self.path_edit.text()
+        if not path:
+            QMessageBox.warning(self, "Chyba", "Nejprve vyberte soubor")
+            return
+        try:
+            self._file = open(path, "a", encoding="utf-8")
+        except Exception as exc:
+            QMessageBox.warning(self, "Chyba", f"Nelze otevřít soubor:\n{exc}")
+            self._file = None
+            return
+        self.start_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+        self.log_view.append(f"== Logging started {time.ctime()} ==")
+        self._file.write(f"# start {time.ctime()}\n")
+        self._file.flush()
+
+    def stop_logging(self):
+        if not self._file:
+            return
+        self.log_view.append(f"== Logging stopped {time.ctime()} ==")
+        try:
+            self._file.write(f"# stop {time.ctime()}\n")
+            self._file.close()
+        except Exception:
+            pass
+        self._file = None
+        self.start_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+
+    def is_logging(self):
+        return self._file is not None
+
+    def log(self, message: str):
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        line = f"{timestamp} {message}"
+        self.log_view.append(line)
+        if self._file:
+            try:
+                self._file.write(line + "\n")
+                self._file.flush()
+            except Exception:
+                pass
+
+    def closeEvent(self, event):
+        self.stop_logging()
+        event.accept()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+"""Application entry point."""
+
+import sys
+import argparse
+from PyQt5.QtWidgets import QApplication
+
+from ui_main import RadioControlApp
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FT-897 control GUI")
+    parser.add_argument("--debug", action="store_true", help="log CAT bytes")
+    parser.add_argument("--port", help="serial port, e.g. /dev/ttyUSB0")
+    parser.add_argument("--baud", type=int, default=9600, help="baud rate")
+    args = parser.parse_args()
+
+    app = QApplication(sys.argv)
+    window = RadioControlApp(debug=args.debug, port=args.port, baudrate=args.baud)
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/meter_validator.py
+++ b/meter_validator.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Interactive tool for verifying S-meter and power readings."""
+
+import sys
+
+from cat_control import FT897CAT
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: meter_validator.py <serial-port> [baudrate]")
+        return
+    port = sys.argv[1]
+    baud = int(sys.argv[2]) if len(sys.argv) > 2 else 9600
+    cat = FT897CAT()
+    if not cat.connect(port, baudrate=baud):
+        print("Cannot connect to", port)
+        return
+    try:
+        while True:
+            try:
+                s_input = input("Enter observed S-meter value (0-255 or q to quit): ")
+            except EOFError:
+                break
+            if s_input.lower().startswith('q'):
+                break
+            try:
+                expected_s = int(s_input)
+            except ValueError:
+                print("Invalid S-meter value")
+                continue
+            try:
+                p_input = input("Enter observed power value (0-255 or q to quit): ")
+            except EOFError:
+                break
+            if p_input.lower().startswith('q'):
+                break
+            try:
+                expected_p = int(p_input)
+            except ValueError:
+                print("Invalid power value")
+                continue
+            s_val, p_val = cat.get_s_and_power()
+            if s_val is None or p_val is None:
+                print("Failed to read meters from radio")
+                continue
+            print(f"Radio: S={s_val} Power={p_val} | Entered: S={expected_s} Power={expected_p}")
+            if s_val != expected_s or p_val != expected_p:
+                print("Mismatch detected!")
+            else:
+                print("Values match.")
+    finally:
+        cat.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/meters.py
+++ b/meters.py
@@ -1,0 +1,41 @@
+"""Utility functions for formatting meter values."""
+
+from typing import Iterable
+
+
+def format_smeter(raw_s: int) -> str:
+    """Convert raw S-meter value (0-255) to a human-readable string."""
+    thresholds = [16 * i for i in range(1, 10)]
+    if raw_s < thresholds[0]:
+        return "S0"
+    for i, t in enumerate(thresholds[1:], start=1):
+        if raw_s < t:
+            return f"S{i}"
+    extra_db = ((raw_s - thresholds[-1]) // 32) * 10
+    return f"S9+{extra_db}"
+
+
+def format_power(raw_p: int, band_label: str) -> str:
+    """Return power reading in watts for the given band label."""
+    if band_label in {
+        "160 m",
+        "80 m",
+        "60 m",
+        "40 m",
+        "30 m",
+        "20 m",
+        "17 m",
+        "15 m",
+        "12 m",
+        "10 m",
+        "6 m",
+    }:
+        pmax = 100
+    elif band_label == "2 m":
+        pmax = 50
+    elif band_label == "70 cm":
+        pmax = 20
+    else:
+        return "---"
+    watts = round(pmax * raw_p / 255)
+    return f"{watts} W"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyQt5>=5.15
+pyserial

--- a/resources.py
+++ b/resources.py
@@ -1,0 +1,61 @@
+"""Resource constants for FT-897 control UI."""
+
+# Mode codes as per Yaesu CAT manual
+MODE_CODES = {
+    "LSB": 0x00,
+    "USB": 0x01,
+    "CW": 0x02,
+    "CWR": 0x03,
+    "AM": 0x04,
+    "FM": 0x08,
+    "DIG": 0x0A,
+    "PKT": 0x0C,
+    "FMN": 0x88,
+}
+
+# Reverse lookup from CAT mode codes to human readable names
+MODE_NAMES = {v: k for k, v in MODE_CODES.items()}
+
+# Frequency ranges in kHz mapped to band labels
+band_definitions = [
+    ((1800, 2000), "160 m"),
+    ((3500, 3800), "80 m"),
+    ((5250, 5450), "60 m"),
+    ((7000, 7200), "40 m"),
+    ((10100, 10150), "30 m"),
+    ((14000, 14350), "20 m"),
+    ((18068, 18168), "17 m"),
+    ((21000, 21450), "15 m"),
+    ((24890, 24990), "12 m"),
+    ((28000, 29700), "10 m"),
+    ((50000, 52000), "6 m"),
+    ((70000, 70500), "4 m"),
+    ((144000, 146000), "2 m"),
+    ((430000, 440000), "70 cm"),
+    ((76000, 108000), "FM rozhlas"),
+    ((118000, 136975), "Letecké pásmo"),
+    ((137000, 174000), "Rozšířený VHF RX"),
+    ((420000, 470000), "UHF RX"),
+]
+
+# Default tuning points for the band selection menu
+band_menu_items = [
+    ("160 m", 1_850_000, MODE_CODES["LSB"]),
+    ("80 m", 3_700_000, MODE_CODES["LSB"]),
+    ("60 m", 5_357_000, MODE_CODES["USB"]),
+    ("40 m", 7_100_000, MODE_CODES["LSB"]),
+    ("30 m", 10_130_000, MODE_CODES["CW"]),
+    ("20 m", 14_200_000, MODE_CODES["USB"]),
+    ("17 m", 18_100_000, MODE_CODES["USB"]),
+    ("15 m", 21_250_000, MODE_CODES["USB"]),
+    ("12 m", 24_950_000, MODE_CODES["USB"]),
+    ("10 m", 28_500_000, MODE_CODES["USB"]),
+    ("6 m", 50_150_000, MODE_CODES["USB"]),
+    ("4 m", 70_200_000, MODE_CODES["FM"]),
+    ("2 m", 145_500_000, MODE_CODES["FM"]),
+    ("70 cm", 433_500_000, MODE_CODES["FM"]),
+    ("FM rozhlas", 100_000_000, MODE_CODES["FM"]),
+    ("Letecké pásmo", 125_000_000, MODE_CODES["AM"]),
+    ("Rozšířený VHF RX", 150_000_000, MODE_CODES["FM"]),
+    ("UHF RX", 440_000_000, MODE_CODES["FM"]),
+]

--- a/tests/test_cat_control.py
+++ b/tests/test_cat_control.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import time
+from cat_control import FT897CAT
+
+class DummySerial:
+    def __init__(self, data: bytes):
+        self.read_buffer = bytearray(data)
+        self.written = bytearray()
+        self.timeout = 0.01
+        self.is_open = True
+    def write(self, data: bytes):
+        self.written.extend(data)
+    def flush(self):
+        pass
+    def read(self, size: int = 1):
+        if not self.read_buffer:
+            time.sleep(self.timeout)
+            return b''
+        data = self.read_buffer[:size]
+        del self.read_buffer[:size]
+        return bytes(data)
+    def reset_input_buffer(self):
+        pass
+    def reset_output_buffer(self):
+        pass
+    def close(self):
+        self.is_open = False
+
+def test_get_meter_block_with_echo():
+    # command echo plus filler byte before meter block
+    response = b'\x00\x00\x00\x00\xE7' + b'\x00' + b'\x10\x20\x30\x40\x50'
+    fake = DummySerial(response)
+    cat = FT897CAT()
+    cat.serial_port = fake
+    cat.is_connected = True
+    block = cat.get_meter_block()
+    assert block == b'\x10\x20\x30\x40\x50'
+    assert fake.written == b'\x00\x00\x00\x00\xE7'
+
+def test_get_meter_block_short():
+    response = b'\x01\x02\x03\x04\x05'
+    fake = DummySerial(response)
+    cat = FT897CAT()
+    cat.serial_port = fake
+    cat.is_connected = True
+    block = cat.get_meter_block()
+    assert block == b'\x01\x02\x03\x04\x05'
+
+def test_get_s_and_power():
+    response = b'\x00\x00\x00\x00\xE7' + b'\xAA\xBB\xCC\xDD\xEE'
+    fake = DummySerial(response)
+    cat = FT897CAT()
+    cat.serial_port = fake
+    cat.is_connected = True
+    s_val, p_val = cat.get_s_and_power()
+    assert s_val == 0xAA
+    assert p_val == 0xBB

--- a/tests/test_meters.py
+++ b/tests/test_meters.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from meters import format_smeter, format_power
+
+
+def test_format_smeter():
+    assert format_smeter(0) == "S0"
+    assert format_smeter(16) == "S1"
+    assert format_smeter(176) == "S9+10"
+
+
+def test_format_power():
+    assert format_power(255, "160 m") == "100 W"
+    assert format_power(128, "2 m") == "25 W"
+    assert format_power(0, "70 cm") == "0 W"

--- a/ui_main.py
+++ b/ui_main.py
@@ -1,0 +1,467 @@
+"""PyQt5 GUI for FT-897 control."""
+
+import serial.tools.list_ports
+from PyQt5.QtCore import Qt, QTimer, pyqtSlot
+from PyQt5.QtGui import QFont, QFontMetrics
+from PyQt5.QtWidgets import (
+    QAction,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFrame,
+    QLabel,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
+    QRadioButton,
+    QPushButton,
+    QSizePolicy,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+    QFontDialog,
+)
+
+from log_window import LogWindow
+
+from cat_control import SerialWorker
+from meters import format_power, format_smeter
+from resources import MODE_CODES, MODE_NAMES, band_definitions, band_menu_items
+
+
+class RadioControlApp(QMainWindow):
+    """Main window class."""
+
+    def __init__(self, debug: bool = False, port: str = None, baudrate: int = 9600):
+        super().__init__()
+        self.debug = debug
+        self.worker: SerialWorker | None = None
+        self._cmd_port = port
+        self._cmd_baud = baudrate
+
+        self.ptt_heartbeat = QTimer(self)
+        self.ptt_heartbeat.setInterval(300)
+        self.ptt_heartbeat.timeout.connect(self.send_ptt_on)
+
+        self.resize_timer = QTimer(self)
+        self.resize_timer.setSingleShot(True)
+        self.resize_timer.timeout.connect(self.adjust_all_fonts)
+
+        # logging dialog for saving meter changes
+        self.log_window = LogWindow(self)
+
+        self.current_font_family = "Courier New"
+        self.freq_text = "000,00000"
+        self.current_theme = "dark"
+        self.last_valid_frequency = None
+        self.last_mode = None
+        self._last_s = None
+        self._last_p = None
+        self._last_power_band = None
+
+        self.band_definitions = band_definitions
+        self.band_menu_items = band_menu_items
+
+        self.band_range_map = {label: rng for rng, label in self.band_definitions}
+        self.band_mode_map = {label: mode for label, _freq, mode in self.band_menu_items}
+
+        self.init_ui()
+        self.apply_stylesheet(self.current_theme)
+
+    # ------------------------ UI Setup ------------------------
+    def init_ui(self):
+        self.setWindowTitle("Ovl\u00e1d\u00e1n\u00ed r\u00e1dia")
+        self.setGeometry(100, 100, 800, 400)
+
+        self.central = QWidget()
+        self.setCentralWidget(self.central)
+        self.layout = QVBoxLayout(self.central)
+
+        self.port_combo = QComboBox()
+        for port in serial.tools.list_ports.comports():
+            self.port_combo.addItem(port.device)
+        self.layout.addWidget(self.port_combo)
+
+        self.connect_btn = QPushButton("P\u0159ipojit")
+        self.connect_btn.clicked.connect(self.toggle_connection)
+        self.layout.addWidget(self.connect_btn)
+
+        self.tabs = QTabWidget()
+        self.layout.addWidget(self.tabs)
+
+        # Frequency tab
+        self.freq_tab = QWidget()
+        self.freq_layout = QVBoxLayout(self.freq_tab)
+
+        self.freq_label = QLabel(self.freq_text)
+        self.freq_label.setAlignment(Qt.AlignCenter)
+        self.freq_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.freq_layout.addWidget(self.freq_label)
+
+        self.band_label = QLabel("")
+        self.band_label.setAlignment(Qt.AlignCenter)
+        self.band_label.setStyleSheet("font-size: 18px;")
+        self.freq_layout.addWidget(self.band_label)
+
+        self.mode_label = QLabel("M\u00f3d: ---")
+        self.mode_label.setAlignment(Qt.AlignCenter)
+        self.mode_label.setStyleSheet("font-size: 18px;")
+        self.mode_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        self.freq_layout.addWidget(self.mode_label)
+
+        self.tabs.addTab(self.freq_tab, "Frekvence")
+
+        # S-meter tab
+        self.smeter_tab = QWidget()
+        self.smeter_layout = QVBoxLayout(self.smeter_tab)
+
+        self.smeter_label = QLabel("S-metr: ---")
+        self.smeter_label.setAlignment(Qt.AlignCenter)
+        self.smeter_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.smeter_layout.addWidget(self.smeter_label)
+
+        self.tabs.addTab(self.smeter_tab, "S-metr")
+
+        # Power tab
+        self.power_tab = QWidget()
+        self.power_layout = QVBoxLayout(self.power_tab)
+
+        self.power_label = QLabel("V\u00fdkon: ---")
+        self.power_label.setAlignment(Qt.AlignCenter)
+        self.power_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.power_layout.addWidget(self.power_label)
+
+        self.tabs.addTab(self.power_tab, "V\u00fdkon")
+
+        self.ptt_container = QFrame()
+        self.ptt_layout = QVBoxLayout(self.ptt_container)
+        self.ptt_btn = QPushButton("PTT")
+        self.ptt_btn.setFont(QFont("Arial", 20, QFont.Bold))
+        self.ptt_btn.setCheckable(True)
+        self.ptt_btn.pressed.connect(self.handle_ptt_on)
+        self.ptt_btn.released.connect(self.handle_ptt_off)
+        self.ptt_btn.setEnabled(False)
+        self.ptt_layout.addWidget(self.ptt_btn)
+        self.layout.addWidget(self.ptt_container)
+
+        self.init_menu()
+
+    def init_menu(self):
+        menubar = self.menuBar()
+        menubar.setStyleSheet(
+            """
+            QMenuBar { background-color: #333; color: white; font-weight: bold; font-size: 16px; }
+            QMenuBar::item { background: transparent; padding: 6px 20px; }
+            QMenuBar::item:selected { background: #555; color: yellow; }
+            QMenu { background-color: #222; color: white; font-size: 15px; }
+            QMenu::item { padding: 6px 24px; }
+            QMenu::item:selected { background-color: #444; color: yellow; }
+            """
+        )
+        view_menu = menubar.addMenu("Zobrazen\u00ed")
+
+        font_action = QAction("Nastavit p\u00edsmo…", self)
+        font_action.triggered.connect(self.choose_font)
+        view_menu.addAction(font_action)
+
+        color_scheme_action = QAction("Nastavit barevn\u00e9 sch\u00e9ma…", self)
+        color_scheme_action.triggered.connect(self.choose_color_scheme)
+        view_menu.addAction(color_scheme_action)
+
+        band_menu = menubar.addMenu("Pásmo")
+        self.power_menu = menubar.addMenu("Výkon")
+        for label, _freq, mode in self.band_menu_items:
+            if label == "2 m":
+                two_m = QMenu("2 m", self)
+                self.add_freq_menu(two_m, "144 MHz", 144000, 145000, 25, MODE_CODES["USB"])
+                self.add_freq_menu(two_m, "145 MHz", 145000, 146000, 25, MODE_CODES["FM"])
+                band_menu.addMenu(two_m)
+                continue
+            if label == "6 m":
+                menu6 = QMenu("6 m", self)
+                self.add_freq_menu(menu6, "50-52 MHz", 50000, 52000, 5, MODE_CODES["USB"])
+                self.add_freq_menu(menu6, "52-54 MHz", 52000, 54000, 25, MODE_CODES["FM"])
+                band_menu.addMenu(menu6)
+                continue
+            if label == "70 cm":
+                menu70 = QMenu("70 cm", self)
+                self.add_freq_menu(menu70, "432-434 MHz", 432000, 434000, 25, MODE_CODES["USB"])
+                self.add_freq_menu(menu70, "434-440 MHz", 434000, 440000, 25, MODE_CODES["FM"])
+                band_menu.addMenu(menu70)
+                continue
+            rng = self.band_range_map.get(label)
+            if label == "10 m" and rng:
+                menu10 = QMenu("10 m", self)
+                start_khz, end_khz = rng
+                self.add_freq_menu(menu10, "10 m", start_khz, end_khz, 10, MODE_CODES["USB"])
+                band_menu.addMenu(menu10)
+                continue
+            if label == "FM rozhlas" and rng:
+                menu_fm = QMenu("FM rozhlas", self)
+                start_khz, end_khz = rng
+                self.add_freq_menu(menu_fm, "FM", start_khz, end_khz, 200, MODE_CODES["FM"])
+                band_menu.addMenu(menu_fm)
+                continue
+            if label == "Letecké pásmo" and rng:
+                menu_air = QMenu("Letecké pásmo", self)
+                start_khz, end_khz = rng
+                self.add_freq_menu(menu_air, "Air", start_khz, end_khz, 100, MODE_CODES["AM"])
+                band_menu.addMenu(menu_air)
+                continue
+            if label in {"Rozšířený VHF RX", "UHF RX"} and rng:
+                sub = QMenu(label, self)
+                start_khz, end_khz = rng
+                step = 100 if label == "Rozšířený VHF RX" else 200
+                self.add_freq_menu(sub, label, start_khz, end_khz, step, MODE_CODES["FM"])
+                band_menu.addMenu(sub)
+                continue
+            if rng:
+                start_khz, end_khz = rng
+                step = 3 if label in {"160 m", "80 m", "60 m", "40 m", "30 m", "20 m", "17 m", "15 m", "12 m"} else 5
+                sub = QMenu(label, self)
+                self.add_freq_menu(sub, label, start_khz, end_khz, step, mode)
+                band_menu.addMenu(sub)
+
+        cmd_menu = menubar.addMenu("P\u0159\u00edkazy")
+        vfo_act = QAction("P\u0159epnout VFO A/B", self)
+        vfo_act.triggered.connect(lambda: self.worker and self.worker.toggle_vfo_req.emit())
+        cmd_menu.addAction(vfo_act)
+
+        split_on_act = QAction("Split ON", self)
+        split_on_act.triggered.connect(lambda: self.worker and self.worker.split_on_req.emit())
+        cmd_menu.addAction(split_on_act)
+
+        split_off_act = QAction("Split OFF", self)
+        split_off_act.triggered.connect(lambda: self.worker and self.worker.split_off_req.emit())
+        cmd_menu.addAction(split_off_act)
+
+        clar_on_act = QAction("Clarifier ON", self)
+        clar_on_act.triggered.connect(lambda: self.worker and self.worker.clar_on_req.emit())
+        cmd_menu.addAction(clar_on_act)
+
+        clar_off_act = QAction("Clarifier OFF", self)
+        clar_off_act.triggered.connect(lambda: self.worker and self.worker.clar_off_req.emit())
+        cmd_menu.addAction(clar_off_act)
+
+        rpt_plus_act = QAction("Repeater +", self)
+        rpt_plus_act.triggered.connect(lambda: self.worker and self.worker.rpt_plus_req.emit())
+        cmd_menu.addAction(rpt_plus_act)
+
+        rpt_minus_act = QAction("Repeater -", self)
+        rpt_minus_act.triggered.connect(lambda: self.worker and self.worker.rpt_minus_req.emit())
+        cmd_menu.addAction(rpt_minus_act)
+
+        log_menu = menubar.addMenu("Log")
+        log_action = QAction("Logovací okno", self)
+        log_action.triggered.connect(self.log_window.show)
+        log_menu.addAction(log_action)
+
+    def add_freq_menu(self, parent: QMenu, label: str, start_khz: int, end_khz: int, step: int, mode_code: int):
+        """Populate a menu with frequency actions on demand."""
+        def populate():
+            parent.clear()
+            for khz in range(start_khz, end_khz + 1, step):
+                freq = khz * 1000
+                act = QAction(f"{khz} kHz", self)
+                act.triggered.connect(lambda _=False, f=freq, m=mode_code: self.goto_band(f, m))
+                parent.addAction(act)
+
+        parent.setTitle(label)
+        parent.aboutToShow.connect(populate)
+
+    # ------------------------ Settings dialogs ------------------------
+    def choose_font(self):
+        font, ok = QFontDialog.getFont(QFont(self.current_font_family, 10), self)
+        if ok:
+            self.current_font_family = font.family()
+            self.adjust_all_fonts()
+
+    def choose_color_scheme(self):
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Vyberte barevn\u00e9 sch\u00e9ma")
+        layout = QVBoxLayout()
+        dark = QRadioButton("Tmav\u00fd re\u017eim")
+        light = QRadioButton("Sv\u011bt\u00bd re\u017eim")
+        contrast = QRadioButton("Vysok\u00fd kontrast")
+        if self.current_theme == "dark":
+            dark.setChecked(True)
+        elif self.current_theme == "light":
+            light.setChecked(True)
+        else:
+            contrast.setChecked(True)
+        layout.addWidget(dark)
+        layout.addWidget(light)
+        layout.addWidget(contrast)
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        layout.addWidget(buttons)
+        dialog.setLayout(layout)
+        if dialog.exec_() == QDialog.Accepted:
+            if dark.isChecked():
+                self.apply_stylesheet("dark")
+            elif light.isChecked():
+                self.apply_stylesheet("light")
+            else:
+                self.apply_stylesheet("contrast")
+
+    def apply_stylesheet(self, theme: str):
+        self.current_theme = theme
+        base_style = (
+            "QWidget { font-family: 'Segoe UI'; }"
+            " QPushButton { padding: 6px; border-radius: 3px; }"
+            " QPushButton:checked { font-weight: bold; }"
+        )
+        if theme == "dark":
+            extra = "QWidget { background-color: #1e1e1e; color: white; }"
+        elif theme == "light":
+            extra = "QWidget { background-color: #ffffff; color: black; }"
+        else:
+            extra = "QWidget { background-color: #000; color: yellow; }"
+        self.setStyleSheet(base_style + extra)
+
+    # ------------------------ Font autosizing ------------------------
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self.resize_timer.start(100)
+
+    def adjust_all_fonts(self):
+        for lbl in [self.freq_label, self.band_label, self.mode_label, self.smeter_label, self.power_label]:
+            self.adjust_label_font(lbl)
+
+    def adjust_label_font(self, label: QLabel):
+        text = label.text()
+        if not text:
+            return
+        width, height = label.width(), label.height()
+        font = QFont(self.current_font_family, 10)
+        low, high, best = 10, 300, 10
+        while low <= high:
+            mid = (low + high) // 2
+            font.setPointSize(mid)
+            metrics = QFontMetrics(font)
+            rect = metrics.boundingRect(text)
+            if rect.width() <= width and rect.height() <= height:
+                best = mid
+                low = mid + 1
+            else:
+                high = mid - 1
+        font.setPointSize(best)
+        label.setFont(font)
+
+    # ------------------------ Main logic ------------------------
+    def toggle_connection(self):
+        if not self.worker:
+            port = self._cmd_port or self.port_combo.currentText()
+            baud = self._cmd_baud
+            self.worker = SerialWorker(port, baud, debug=self.debug)
+            self.worker.status.connect(self.update_status)
+            self.worker.connected.connect(self.on_worker_connected)
+            self.worker.start()
+        else:
+            self.ptt_heartbeat.stop()
+            self.worker.stop()
+            self.worker = None
+            self.ptt_btn.setEnabled(False)
+            self.connect_btn.setText("P\u0159ipojit")
+
+    def on_worker_connected(self, ok: bool):
+        if ok:
+            self.ptt_btn.setEnabled(True)
+            self.connect_btn.setText("Odpojit")
+        else:
+            QMessageBox.warning(self, "Chyba", "Nelze se p\u0159ipojit.")
+            if self.worker is not None:
+                # ensure the thread has fully stopped before deleting
+                self.worker.wait()
+            self.worker = None
+
+    @pyqtSlot(int, int, int, int)
+    def update_status(self, freq_hz: int, mode: int, raw_s: int, raw_p: int):
+        freq_changed = freq_hz != self.last_valid_frequency
+        self.last_valid_frequency = freq_hz
+        self.last_mode = mode
+        freq_mhz = freq_hz / 1_000_000.0
+        formatted = f"{freq_mhz:.5f}".replace('.', ',')
+        if formatted != self.freq_label.text():
+            self.freq_label.setText(formatted)
+        freq_khz = freq_hz / 1000.0
+        band_label = self.get_band_label_from_khz(freq_khz)
+        band_str = f"P\u00e1smo: {band_label}"
+        if band_str != self.band_label.text():
+            self.band_label.setText(band_str)
+        mode_name = MODE_NAMES.get(mode, f"0x{mode:02X}")
+        mode_str = f"M\u00f3d: {mode_name}"
+        if mode_str != self.mode_label.text():
+            self.mode_label.setText(mode_str)
+        self.update_power_menu(band_label)
+
+        if raw_s != self._last_s:
+            self._last_s = raw_s
+            self.smeter_label.setText(f"S-metr: {format_smeter(raw_s)}")
+        if raw_p != self._last_p:
+            self._last_p = raw_p
+            self.power_label.setText(f"V\u00fdkon: {format_power(raw_p, band_label)}")
+        if self.log_window.is_logging():
+            self.log_window.log(f"{freq_hz}Hz {band_label} S={raw_s} P={raw_p}")
+
+    def get_band_label_from_khz(self, freq_khz: float) -> str:
+        for (start, end), label in self.band_definitions:
+            if start <= freq_khz <= end:
+                return label
+        return f"Nezn\u00e1m\u00e9 p\u00e1smo ({freq_khz/1000:.5f} MHz)"
+
+    def handle_ptt_on(self):
+        if not self.worker:
+            return
+        self.worker.ptt_on_req.emit()
+        self.ptt_heartbeat.start()
+        self.ptt_container.setStyleSheet("background-color: #600;")
+
+    def send_ptt_on(self):
+        if self.worker:
+            self.worker.ptt_on_req.emit()
+
+    def handle_ptt_off(self):
+        if not self.worker:
+            return
+        self.ptt_heartbeat.stop()
+        self.worker.ptt_off_req.emit()
+        self.ptt_container.setStyleSheet("")
+
+    def goto_band(self, freq_hz: int, mode_code: int):
+        if not self.worker:
+            return
+        self.worker.set_frequency_req.emit(freq_hz)
+        self.worker.set_mode_req.emit(mode_code)
+
+    def closeEvent(self, event):
+        if self.worker:
+            self.worker.stop()
+        event.accept()
+
+    # ------------------------ Power menu ------------------------
+    def update_power_menu(self, band_label: str):
+        if not hasattr(self, "power_menu"):
+            return
+        if band_label == self._last_power_band:
+            return
+        self._last_power_band = band_label
+        self.power_menu.clear()
+        band_map = {**{b: 100 for b in [
+            "160 m", "80 m", "60 m", "40 m", "30 m", "20 m", "17 m", "15 m", "12 m", "10 m", "6 m"
+        ]}, "2 m": 50, "70 cm": 20}
+        pmax = band_map.get(band_label, 0)
+        for w in range(5, pmax + 1, 5):
+            act = QAction(f"{w} W", self)
+            act.triggered.connect(lambda _=False, watt=w, band=band_label: self.set_power_level(band, watt))
+            self.power_menu.addAction(act)
+
+    def set_power_level(self, band_label: str, watts: int) -> None:
+        """Apply transmit power change without altering frequency."""
+        if self.worker:
+            self.worker.set_power_req.emit(band_label, watts)
+            self.power_label.setText(f"V\u00fdkon: {watts} W")
+            if self.log_window.is_logging():
+                self.log_window.log(f"SET POWER {band_label} {watts}W")
+


### PR DESCRIPTION
## Summary
- route CAT operations from the GUI to the worker thread using signals
- update `SerialWorker` to expose request signals and handle them safely

## Testing
- `python3 -m py_compile *.py tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753c39f0fc83218278fc8f8c0b7cef