### PR TITLE
Refactor into ft897control package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# FT897
+# FT897 CAT Control
+
+This repository contains a simple PyQt5 application for controlling the Yaesu FT-897 via its CAT interface. The program can display the current frequency, S-meter and power, provide PTT control, and offers band presets for quick tuning.  A "Módy" menu lets you change the modulation mode (USB, LSB, CW, AM, FM, etc.) while the "CAT příkazy" menu exposes CAT commands including VFO switching, split mode control, lock and clarifier functions and CTCSS/DCS configuration.  The band menu now covers CB, PMR446, the airband, FM broadcast and several shortwave broadcast bands.  The 15 m band spans the full 21.000–21.450 MHz range in USB mode, and the 70 cm band is split into a 432–434 MHz USB submenu and a 438–440 MHz FM submenu.  The SWR tab shows "High" only during transmission when the radio reports a VSWR alarm via the TX status byte.  A "Paměti" menu provides quick access to stored channels with FM stations like ČRo Radiožurnál, Frekvence 1, Rock Radio, Rádio Beat, Rádio Impuls, Hitrádio Faktor, Evropa 2, ČRo České Budějovice, Radio Niederösterreich, Ö1, Ö1 Jauerling, FM4, ČRo Dvojka, Metro Life Radio, ČRo Plus, Frekvence 1 Jihlava, Rádio Kiss, ČRo Radiožurnál Votice Mezivrata and Country Radio.
+
+## Power control
+
+According to the Yaesu CAT Operation Reference and the Hamlib implementation of the FT‑897/857 protocol, the transceiver does **not** provide a command for setting the RF output power remotely. The output power must be adjusted manually on the radio. The application therefore only displays power levels. It continuously polls the radio’s TX status byte (`0xF7`) and when transmission is detected it converts the returned power nibble to a percentage of the calibrated range for the current band.
+
+## PMR446 frequencies
+
+PMR446 channels are included from 446.00625 MHz to 446.19375 MHz in 12.5 kHz steps (16 channels in total) and are tuned using FM mode.

--- a/ft897_control.py
+++ b/ft897_control.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import sys
+import subprocess
+
+required = ["pyserial", "PyQt5"]
+for module in required:
+    try:
+        __import__(module)
+    except ImportError:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", module])
+
+from ft897control.ui import main
+
+if __name__ == "__main__":
+    main()

--- a/ft897control/__init__.py
+++ b/ft897control/__init__.py
@@ -1,0 +1,13 @@
+"""FT-897 CAT control package"""
+
+from .cat_controller import FT897CAT
+from .memory_controller import MemoryController
+from .memory_manager import MemoryManager
+from .ui import RadioControlApp
+
+__all__ = [
+    "FT897CAT",
+    "MemoryController",
+    "MemoryManager",
+    "RadioControlApp",
+]

--- a/ft897control/cat_controller.py
+++ b/ft897control/cat_controller.py
@@ -1,0 +1,158 @@
+import serial
+import threading
+import time
+from typing import Optional
+
+class FT897CAT:
+    """Low-level CAT controller for the Yaesu FT-897."""
+
+    MODE_MAP = {
+        "LSB": 0x00,
+        "USB": 0x01,
+        "CW": 0x02,
+        "CWR": 0x03,
+        "AM": 0x04,
+        "FM": 0x08,
+        "DIG": 0x06,
+    }
+
+    def __init__(self) -> None:
+        self.port: Optional[str] = None
+        self.baudrate: int = 9600
+        self.serial_port: Optional[serial.Serial] = None
+        self.is_connected: bool = False
+        self.ptt_active: bool = False
+        self._lock = threading.Lock()
+
+    def _send(self, data: bytes) -> bool:
+        """Send raw bytes to the radio."""
+        with self._lock:
+            try:
+                assert self.serial_port
+                self.serial_port.reset_input_buffer()
+                self.serial_port.reset_output_buffer()
+                self.serial_port.write(data)
+                self.serial_port.flush()
+                time.sleep(0.05)
+                return True
+            except Exception:
+                return False
+
+    def _read(self, length: int = 5) -> Optional[bytes]:
+        """Read raw bytes from the radio."""
+        with self._lock:
+            try:
+                assert self.serial_port
+                return self.serial_port.read(length)
+            except Exception:
+                return None
+
+    # connection ---------------------------------------------------------
+    def connect(self, port: str, baudrate: int = 9600) -> bool:
+        """Open the serial port."""
+        self.port = port
+        self.baudrate = baudrate
+        try:
+            self.serial_port = serial.Serial(
+                port=port,
+                baudrate=baudrate,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=0.2,
+                write_timeout=0.2,
+            )
+            self.is_connected = True
+            return True
+        except Exception:
+            self.serial_port = None
+            self.is_connected = False
+            return False
+
+    def disconnect(self) -> None:
+        """Close the serial port."""
+        if self.serial_port and self.serial_port.is_open:
+            try:
+                self.serial_port.close()
+            except Exception:
+                pass
+        self.serial_port = None
+        self.is_connected = False
+
+    # radio queries ------------------------------------------------------
+    def get_frequency(self) -> Optional[int]:
+        """Return current VFO frequency in Hz."""
+        if not self.is_connected:
+            return None
+        if not self._send(b"\x00\x00\x00\x00\x03"):
+            return None
+        resp = self._read(5)
+        if not resp or len(resp) != 5:
+            return None
+        units_10hz = 0
+        for b in resp[:4]:
+            units_10hz = units_10hz * 100 + ((b >> 4) & 0x0F) * 10 + (b & 0x0F)
+        return units_10hz * 10
+
+    def set_frequency(self, freq_hz: int) -> bool:
+        """Tune the radio to ``freq_hz``."""
+        if not self.is_connected:
+            return False
+        units_10hz = int(freq_hz // 10)
+        digits = f"{units_10hz:08d}"
+        bcd = bytearray()
+        for i in range(0, 8, 2):
+            bcd.append((int(digits[i]) << 4) | int(digits[i + 1]))
+        return self._send(bytes(bcd) + b"\x01")
+
+    def read_rx_status(self) -> Optional[int]:
+        """Return RX status byte (opcode ``0xE7``)."""
+        if not self.is_connected:
+            return None
+        if not self._send(b"\x00\x00\x00\x00\xe7"):
+            return None
+        resp = self._read(1)
+        return resp[0] if resp else None
+
+    def read_tx_status(self) -> Optional[int]:
+        """Return TX status byte (opcode ``0xF7``)."""
+        if not self.is_connected:
+            return None
+        if not self._send(b"\x00\x00\x00\x00\xf7"):
+            return None
+        resp = self._read(1)
+        return resp[0] if resp else None
+
+    def get_mode(self) -> Optional[str]:
+        """Return mode name decoded from RX status."""
+        status = self.read_rx_status()
+        if status is None:
+            return None
+        code = status & 0x0F
+        for name, val in self.MODE_MAP.items():
+            if val == code:
+                return name
+        return None
+
+    def set_mode(self, mode: str) -> bool:
+        """Switch the radio to the specified mode name."""
+        if not self.is_connected:
+            return False
+        code = self.MODE_MAP.get(mode)
+        if code is None:
+            return False
+        cmd = bytes([code, 0x00, 0x00, 0x00, 0x07])
+        return self._send(cmd)
+
+    # ptt ---------------------------------------------------------------
+    def ptt_on(self) -> bool:
+        if not self.is_connected:
+            return False
+        self.ptt_active = True
+        return self._send(b"\x00\x00\x00\x00\x08")
+
+    def ptt_off(self) -> bool:
+        if not self.is_connected:
+            return False
+        self.ptt_active = False
+        return self._send(b"\x00\x00\x00\x00\x88")

--- a/ft897control/memory_controller.py
+++ b/ft897control/memory_controller.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+
+from .cat_controller import FT897CAT
+
+class MemoryController:
+    """Access FT-897 memory channels over CAT."""
+
+    def __init__(self, cat: FT897CAT) -> None:
+        self.cat = cat
+
+    def _send(self, data: bytes) -> bool:
+        return self.cat._send(data)
+
+    def _read(self, length: int = 5) -> Optional[bytes]:
+        return self.cat._read(length)
+
+    def get_memory_channels(self) -> List[Tuple[int, int, str]]:
+        """Return list of (index, freq_hz, mode)."""
+        channels: List[Tuple[int, int, str]] = []
+        if not self.cat.is_connected:
+            return channels
+        for idx in range(1, 101):
+            cmd = bytes([0x00, idx & 0xFF, 0x00, 0x00, 0xB0])
+            if not self._send(cmd):
+                break
+            resp = self._read(5)
+            if not resp or len(resp) != 5:
+                continue
+            freq = 0
+            for b in resp[:4]:
+                freq = freq * 100 + ((b >> 4) & 0x0F) * 10 + (b & 0x0F)
+            freq *= 10
+            mode_code = resp[4] & 0x0F
+            mode = next((n for n, v in FT897CAT.MODE_MAP.items() if v == mode_code), "FM")
+            channels.append((idx, freq, mode))
+        return channels
+
+    def set_memory_channel(self, index: int, freq_hz: int, mode: str) -> bool:
+        """Store a memory entry at ``index``."""
+        if not self.cat.is_connected:
+            return False
+        units_10hz = int(freq_hz // 10)
+        digits = f"{units_10hz:08d}"
+        bcd = bytearray()
+        for i in range(0, 8, 2):
+            bcd.append((int(digits[i]) << 4) | int(digits[i+1]))
+        mode_code = FT897CAT.MODE_MAP.get(mode, 0x08)
+        cmd = bytes([0x00, index & 0xFF]) + bytes(bcd) + bytes([mode_code])
+        cmd = cmd[:4] + b"\xB1"
+        return self._send(cmd)
+
+    def delete_memory_channel(self, index: int) -> bool:
+        if not self.cat.is_connected:
+            return False
+        cmd = bytes([0x00, index & 0xFF, 0x00, 0x00, 0xB2])
+        return self._send(cmd)

--- a/ft897control/memory_manager.py
+++ b/ft897control/memory_manager.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from .cat_controller import FT897CAT
+from .memory_controller import MemoryController
+
+class MemoryManager:
+    """Manage presets synchronized with the radio memories."""
+
+    def __init__(self, cat: FT897CAT):
+        self.cat = cat
+        self.ctrl = MemoryController(cat)
+        self.entries: List[Tuple[str, int, str]] = []
+
+    def load_from_radio(self) -> None:
+        self.entries.clear()
+        for idx, freq, mode in self.ctrl.get_memory_channels():
+            name = f"MEM {idx}"
+            self.entries.append((name, freq, mode))
+
+    def add_entry(self, name: str, freq_hz: int, mode: str) -> None:
+        index = len(self.entries) + 1
+        if self.ctrl.set_memory_channel(index, freq_hz, mode):
+            self.entries.append((name, freq_hz, mode))
+
+    def delete_entry(self, index: int) -> None:
+        if 0 <= index < len(self.entries):
+            if self.ctrl.delete_memory_channel(index + 1):
+                self.entries.pop(index)

--- a/ft897control/ui.py
+++ b/ft897control/ui.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import sys
+from typing import Tuple
+
+from PyQt5.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QLabel, QPushButton,
+    QComboBox, QMessageBox, QAction, QSizePolicy, QTabWidget, QMenu
+)
+from PyQt5.QtCore import Qt, QThread, pyqtSignal, QTimer
+from PyQt5.QtGui import QFont
+
+from .cat_controller import FT897CAT
+from .memory_manager import MemoryManager
+
+class StatusThread(QThread):
+    status_updated = pyqtSignal(int, int, int, int, int, str)
+
+    def __init__(self, cat: FT897CAT) -> None:
+        super().__init__()
+        self.cat = cat
+        self.running = False
+
+    def run(self) -> None:
+        self.running = True
+        while self.running:
+            if self.cat.is_connected:
+                freq = self.cat.get_frequency() or 0
+                rx = self.cat.read_rx_status() or 0
+                tx = self.cat.read_tx_status() or 0
+                sm = (rx >> 4) & 0x0F
+                mode_code = rx & 0x0F
+                mode = next((n for n,v in FT897CAT.MODE_MAP.items() if v==mode_code), "")
+                ptt = 0 if (tx & 0x80) else 1
+                power = tx & 0x0F if ptt else -1
+                swr = 1 if (ptt and (tx & 0x40)) else (0 if ptt else -1)
+                self.status_updated.emit(freq, sm, power, swr, ptt, mode)
+            self.msleep(150)
+
+    def stop(self) -> None:
+        self.running = False
+
+class RadioControlApp(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cat = FT897CAT()
+        self.mem_manager = MemoryManager(self.cat)
+        self.status_thread = StatusThread(self.cat)
+        self.status_thread.status_updated.connect(self.update_status)
+        self.ptt_heartbeat = QTimer(self)
+        self.ptt_heartbeat.setInterval(100)
+        self.ptt_heartbeat.timeout.connect(self.cat.ptt_on)
+        self.last_freq = None
+
+        self.init_ui()
+
+    def init_ui(self) -> None:
+        self.setWindowTitle("FT-897 CAT Control")
+        self.resize(800, 400)
+        central = QWidget()
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+        self.port_combo = QComboBox()
+        from serial.tools import list_ports
+        for p in list_ports.comports():
+            self.port_combo.addItem(p.device)
+        layout.addWidget(self.port_combo)
+        self.connect_btn = QPushButton("Connect")
+        self.connect_btn.clicked.connect(self.toggle_connection)
+        layout.addWidget(self.connect_btn)
+
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+        self.freq_label = QLabel("000,00000")
+        self.freq_label.setAlignment(Qt.AlignCenter)
+        self.freq_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.freq_label.setFont(QFont("Courier New", 16, QFont.Bold))
+        freq_tab = QWidget()
+        v = QVBoxLayout(freq_tab)
+        v.addWidget(self.freq_label)
+        self.tabs.addTab(freq_tab, "Frekvence")
+
+        self.smeter_label = QLabel("S-metr: ---")
+        self.smeter_label.setAlignment(Qt.AlignCenter)
+        sm_tab = QWidget(); sm_l = QVBoxLayout(sm_tab); sm_l.addWidget(self.smeter_label)
+        self.tabs.addTab(sm_tab, "S-metr")
+
+        self.swr_label = QLabel("SWR: ---")
+        swr_tab = QWidget(); swr_l = QVBoxLayout(swr_tab); swr_l.addWidget(self.swr_label)
+        self.tabs.addTab(swr_tab, "SWR")
+
+        self.power_label = QLabel("Výkon: ---")
+        pw_tab = QWidget(); pw_l = QVBoxLayout(pw_tab); pw_l.addWidget(self.power_label)
+        self.tabs.addTab(pw_tab, "Výkon")
+
+        self.ptt_label = QLabel("Příjem")
+        ptt_tab = QWidget(); pt_l = QVBoxLayout(ptt_tab); pt_l.addWidget(self.ptt_label)
+        self.tabs.addTab(ptt_tab, "PTT")
+
+        self.mode_label = QLabel("Mód: ---")
+        mode_tab = QWidget(); mo_l = QVBoxLayout(mode_tab); mo_l.addWidget(self.mode_label)
+        self.tabs.addTab(mode_tab, "Mód")
+
+        self.ptt_btn = QPushButton("PTT")
+        self.ptt_btn.setCheckable(True)
+        self.ptt_btn.pressed.connect(self.handle_ptt_on)
+        self.ptt_btn.released.connect(self.handle_ptt_off)
+        self.ptt_btn.setEnabled(False)
+        layout.addWidget(self.ptt_btn)
+
+        self.init_menu()
+
+    def init_menu(self) -> None:
+        menubar = self.menuBar()
+        self.memory_menu = menubar.addMenu("Paměti")
+        self.rebuild_memory_menu()
+
+    def rebuild_memory_menu(self) -> None:
+        self.memory_menu.clear()
+        for idx, (name, freq, mode) in enumerate(self.mem_manager.entries, 1):
+            act = QAction(f"{idx:02d} {name}", self)
+            act.setData((freq, mode))
+            act.triggered.connect(self.tune_from_action)
+            self.memory_menu.addAction(act)
+
+    def tune_from_action(self) -> None:
+        act = self.sender()
+        if not act or not self.cat.is_connected:
+            return
+        freq, mode = act.data()
+        self.cat.set_frequency(freq)
+        self.cat.set_mode(mode)
+
+    # ------------------------------------------------------------------
+    def toggle_connection(self) -> None:
+        if not self.cat.is_connected:
+            port = self.port_combo.currentText()
+            if self.cat.connect(port):
+                self.mem_manager.load_from_radio()
+                self.rebuild_memory_menu()
+                self.status_thread.start()
+                self.ptt_btn.setEnabled(True)
+                self.connect_btn.setText("Disconnect")
+            else:
+                QMessageBox.warning(self, "Chyba", "Nelze se připojit")
+        else:
+            self.status_thread.stop(); self.status_thread.wait()
+            self.cat.disconnect()
+            self.ptt_btn.setEnabled(False)
+            self.connect_btn.setText("Connect")
+
+    def update_status(self, freq, sm, power, swr, ptt, mode) -> None:
+        self.last_freq = freq
+        self.freq_label.setText(f"{freq/1_000_000:.5f}".replace('.', ','))
+        self.smeter_label.setText(f"S-metr: {sm}" if sm >=0 else "S-metr: ---")
+        self.power_label.setText(f"Výkon: {power}" if power>=0 else "Výkon: ---")
+        if swr == 1:
+            self.swr_label.setText("SWR: High")
+        elif swr == 0:
+            self.swr_label.setText("SWR: Normal")
+        else:
+            self.swr_label.setText("SWR: ---")
+        self.ptt_label.setText("Vysílání" if ptt else "Příjem")
+        self.mode_label.setText(f"Mód: {mode}" if mode else "Mód: ---")
+
+    def handle_ptt_on(self) -> None:
+        if self.cat.ptt_on():
+            self.ptt_heartbeat.start()
+
+    def handle_ptt_off(self) -> None:
+        self.ptt_heartbeat.stop()
+        self.cat.ptt_off()
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    win = RadioControlApp()
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restructure code into modular `ft897control` package
- implement `FT897CAT` in `cat_controller.py`
- add basic memory access helpers and a `MemoryManager`
- move the GUI into `ui.py` and update main script

## Testing
- `python3 -m py_compile ft897_control.py ft897control/*.py`
- `env QT_QPA_PLATFORM=offscreen timeout 5s python3 ft897_control.py`

------
https://chatgpt.com/codex/tasks/task_e_68790ecc74648321982c26201753b32d