### PR TITLE
Add accessible FT-897 remote control web server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+
+# Editor directories
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# FT897
+# FT-897 Remote Control Server
+
+Tato aplikace poskytuje přístupný webový server napsaný v jazyce Python,
+který umožňuje ovládání radiostanice Yaesu FT-897 přes CAT rozhraní a
+streamování zvuku z připojené zvukové karty.
+
+## Vlastnosti
+
+- **CAT ovládání** – nastavení frekvence, přepínání PTT a odesílání
+  libovolných CAT příkazů přes jednoduché webové rozhraní.
+- **Přístupnost** – stránky jsou optimalizované pro zrakově postižené,
+  využívají vysoký kontrast, větší písmo a prvky ARIA.
+- **Audio streaming** – stream zvuku ve formátu WAV z libovolného
+  vstupního zařízení systému (například zvukové karty připojené ke
+  stanici).
+
+## Požadavky
+
+- Python 3.10+
+- Nainstalované balíčky uvedené v `requirements.txt`
+- Pro CAT komunikaci balíček `pyserial` a dostupný sériový port
+- Pro audio streaming knihovna `sounddevice` (vyžaduje PortAudio)
+
+## Instalace
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Konfigurace
+
+Server lze konfigurovat pomocí proměnných prostředí nebo souboru `.env`.
+
+| Proměnná | Výchozí hodnota | Popis |
+| --- | --- | --- |
+| `FT897_SERIAL_PORT` | `/dev/ttyUSB0` | Sériový port připojené stanice |
+| `FT897_BAUDRATE` | `9600` | Přenosová rychlost CAT rozhraní |
+| `FT897_SERIAL_TIMEOUT` | `1.0` | Timeout (s) pro CAT komunikaci |
+| `FT897_SIMULATE` | `False` | Pokud je `True`, neotevírá sériový port a odpovědi se simulují |
+| `FT897_AUDIO_SAMPLERATE` | `16000` | Vzorkovací frekvence audio streamu |
+| `FT897_AUDIO_CHANNELS` | `1` | Počet kanálů audio streamu |
+| `FT897_AUDIO_BLOCKSIZE` | `1024` | Velikost bloku (počet vzorků) |
+| `FT897_AUDIO_ENABLED` | `True` | Povolit/zakázat audio stream |
+| `FT897_AUDIO_DEVICE` | `None` | Index zařízení pro `sounddevice`, ponechte prázdné pro výchozí |
+
+Příklad `.env` souboru:
+
+```env
+FT897_SERIAL_PORT=/dev/ttyUSB0
+FT897_BAUDRATE=9600
+FT897_SIMULATE=True
+```
+
+## Spuštění
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Aplikace poběží na adrese <http://127.0.0.1:8000>.
+
+## Poznámky
+
+- V režimu simulace (`FT897_SIMULATE=True`) server vrací ukázkové
+  odpovědi a nevyžaduje připojenou radiostanici.
+- Pro správné fungování audio streamu je nutné mít nainstalován PortAudio
+  (například balíček `portaudio19-dev` na Debian/Ubuntu) a odpovídající
+  zvukové zařízení.

--- a/app/audio_stream.py
+++ b/app/audio_stream.py
@@ -1,0 +1,125 @@
+"""Audio streaming utilities."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import struct
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional
+
+try:
+    import sounddevice  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    sounddevice = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AudioConfig:
+    """Configuration for capturing audio from the host sound card."""
+
+    samplerate: int = 16000
+    channels: int = 1
+    blocksize: int = 1024
+    subtype: str = "int16"
+    device: Optional[int] = None
+    enabled: bool = True
+
+
+class AudioStreamer:
+    """Stream audio from the system's sound card as linear PCM WAV data."""
+
+    def __init__(self, config: AudioConfig):
+        self._config = config
+        self._queue: "asyncio.Queue[bytes]" = asyncio.Queue(maxsize=10)
+        self._stream: Optional["sounddevice.RawInputStream"] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._running = False
+
+    def _audio_callback(self, indata, frames, time, status) -> None:  # pragma: no cover - callback
+        if status:
+            LOGGER.warning("Audio callback status: %s", status)
+        if not self._running:
+            return
+        data = bytes(indata)
+        try:
+            self._queue.put_nowait(data)
+        except asyncio.QueueFull:
+            LOGGER.debug("Audio queue full; dropping frame")
+
+    def _wav_header(self) -> bytes:
+        byte_rate = self._config.samplerate * self._config.channels * 2
+        block_align = self._config.channels * 2
+        header = struct.pack(
+            "<4sI4s4sIHHIIHH4sI",
+            b"RIFF",
+            36 + 0x7FFFFFFF,  # huge placeholder size for streaming
+            b"WAVE",
+            b"fmt ",
+            16,
+            1,
+            self._config.channels,
+            self._config.samplerate,
+            byte_rate,
+            block_align,
+            16,
+            b"data",
+            0x7FFFFFFF,
+        )
+        return header
+
+    async def audio_generator(self) -> AsyncIterator[bytes]:
+        if not self._config.enabled:
+            LOGGER.info("Audio streaming is disabled via configuration")
+            raise RuntimeError("Audio streaming disabled")
+
+        if sounddevice is None:
+            raise RuntimeError(
+                "sounddevice is not available. Install it with 'pip install sounddevice'."
+            )
+
+        self._loop = asyncio.get_running_loop()
+        self._running = True
+        LOGGER.info(
+            "Starting audio capture: %d Hz, %d channel(s)",
+            self._config.samplerate,
+            self._config.channels,
+        )
+        try:
+            self._stream = sounddevice.RawInputStream(  # type: ignore[call-arg]
+                samplerate=self._config.samplerate,
+                channels=self._config.channels,
+                dtype=self._config.subtype,
+                blocksize=self._config.blocksize,
+                device=self._config.device,
+                callback=self._audio_callback,
+            )
+            self._stream.start()
+        except Exception as exc:  # pragma: no cover - hardware dependent
+            LOGGER.error("Unable to start audio stream: %s", exc)
+            raise
+
+        yield self._wav_header()
+
+        try:
+            while self._running:
+                chunk = await self._queue.get()
+                yield chunk
+        finally:
+            await self.stop()
+
+    async def stop(self) -> None:
+        if self._stream is not None:
+            LOGGER.info("Stopping audio capture")
+            try:
+                self._stream.stop()
+                self._stream.close()
+            finally:
+                self._stream = None
+        self._running = False
+        while not self._queue.empty():
+            self._queue.get_nowait()
+
+
+__all__ = ["AudioConfig", "AudioStreamer"]

--- a/app/cat_control.py
+++ b/app/cat_control.py
@@ -1,0 +1,175 @@
+"""CAT control utilities for Yaesu FT-897."""
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import serial  # type: ignore
+except Exception:  # pragma: no cover - optional dependency during development
+    serial = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CATConfig:
+    """Configuration parameters for the CAT interface."""
+
+    port: str = "/dev/ttyUSB0"
+    baudrate: int = 9600
+    timeout: float = 1.0
+    simulate: bool = False
+
+
+class FT897Controller:
+    """Simple CAT controller for the Yaesu FT-897 transceiver.
+
+    The implementation focuses on a subset of useful commands to keep the
+    interface approachable while still allowing the user to send raw CAT
+    commands for advanced operations.
+    """
+
+    def __init__(self, config: CATConfig):
+        self._config = config
+        self._serial: Optional["serial.Serial"] = None
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+    def connect(self) -> None:
+        """Establish a serial connection if it is not already open."""
+
+        if self._config.simulate:
+            LOGGER.debug("Simulation mode active; not opening serial port.")
+            return
+
+        if serial is None:
+            raise RuntimeError(
+                "pyserial is not available. Install it with 'pip install pyserial'."
+            )
+
+        if self._serial and self._serial.is_open:
+            return
+
+        LOGGER.info(
+            "Opening CAT serial connection on %s at %d baud",
+            self._config.port,
+            self._config.baudrate,
+        )
+        self._serial = serial.Serial(  # type: ignore[call-arg]
+            port=self._config.port,
+            baudrate=self._config.baudrate,
+            timeout=self._config.timeout,
+        )
+
+    def disconnect(self) -> None:
+        """Close the serial connection."""
+
+        if self._serial and self._serial.is_open:
+            LOGGER.info("Closing CAT serial connection")
+            self._serial.close()
+            self._serial = None
+
+    # ------------------------------------------------------------------
+    # Command helpers
+    # ------------------------------------------------------------------
+    def send_raw_command(self, command: str) -> str:
+        """Send a raw CAT command.
+
+        The command string is automatically terminated with ``;`` if the caller
+        does not add it manually. The response from the transceiver (if any) is
+        returned as a plain string without the trailing delimiter.
+        """
+
+        command = command.strip().upper()
+        if not command:
+            raise ValueError("Command must not be empty")
+
+        if not command.endswith(";"):
+            command += ";"
+
+        LOGGER.debug("Sending CAT command: %s", command)
+
+        if self._config.simulate:
+            return self._simulate_command(command)
+
+        if serial is None:
+            raise RuntimeError("pyserial is required for CAT communication")
+
+        self.connect()
+        assert self._serial is not None  # for type checkers
+
+        with self._lock:
+            self._serial.reset_input_buffer()
+            self._serial.write(command.encode("ascii"))
+            self._serial.flush()
+            response = self._serial.read_until(b";")
+
+        response_text = response.decode("ascii", errors="ignore").strip()
+        LOGGER.debug("CAT response: %s", response_text)
+        return response_text
+
+    # ------------------------------------------------------------------
+    # Convenience methods for common operations
+    # ------------------------------------------------------------------
+    def get_vfo_a_frequency(self) -> Optional[int]:
+        """Return the current VFO-A frequency in Hertz."""
+
+        response = self.send_raw_command("FA;")
+        if not response.startswith("FA"):
+            return None
+        digits = response[2:].strip(";")
+        try:
+            return int(digits)
+        except ValueError:
+            LOGGER.warning("Unable to parse FA response: %s", response)
+            return None
+
+    def set_vfo_a_frequency(self, frequency_hz: int) -> None:
+        """Set the VFO-A frequency (in Hertz)."""
+
+        if not 100000 <= frequency_hz <= 500000000:
+            raise ValueError("Frequency must be between 100 kHz and 500 MHz")
+        command = f"FA{frequency_hz:011d}"
+        self.send_raw_command(command)
+
+    def get_ptt_status(self) -> Optional[bool]:
+        """Return the Push-To-Talk status if available."""
+
+        response = self.send_raw_command("TX;")
+        if response in {"TX0", "TX0;"}:
+            return False
+        if response in {"TX1", "TX1;"}:
+            return True
+        return None
+
+    def set_ptt(self, active: bool) -> None:
+        """Toggle transmission."""
+
+        command = "TX1" if active else "TX0"
+        self.send_raw_command(command)
+
+    # ------------------------------------------------------------------
+    # Simulation helpers
+    # ------------------------------------------------------------------
+    def _simulate_command(self, command: str) -> str:
+        """Return a fake response when running without a radio attached."""
+
+        LOGGER.debug("Simulated CAT command: %s", command)
+        command = command.strip(";")
+        if command == "FA":
+            return "FA0140740000;"  # Example frequency
+        if command.startswith("FA"):
+            return "OK;"
+        if command == "TX":
+            return "TX0;"
+        if command in {"TX0", "TX1"}:
+            return "OK;"
+        return ";"
+
+
+__all__ = ["CATConfig", "FT897Controller"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,155 @@
+"""FastAPI application for remote control of the Yaesu FT-897."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, BaseSettings, Field, validator
+
+from .audio_stream import AudioConfig, AudioStreamer
+from .cat_control import CATConfig, FT897Controller
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Settings(BaseSettings):
+    serial_port: str = Field("/dev/ttyUSB0", env="FT897_SERIAL_PORT")
+    baudrate: int = Field(9600, env="FT897_BAUDRATE")
+    serial_timeout: float = Field(1.0, env="FT897_SERIAL_TIMEOUT")
+    simulate_radio: bool = Field(False, env="FT897_SIMULATE")
+
+    audio_samplerate: int = Field(16000, env="FT897_AUDIO_SAMPLERATE")
+    audio_channels: int = Field(1, env="FT897_AUDIO_CHANNELS")
+    audio_blocksize: int = Field(1024, env="FT897_AUDIO_BLOCKSIZE")
+    audio_enabled: bool = Field(True, env="FT897_AUDIO_ENABLED")
+    audio_device: Optional[int] = Field(None, env="FT897_AUDIO_DEVICE")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @validator("baudrate")
+    def _validate_baudrate(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("Baudrate must be positive")
+        return value
+
+
+class CommandRequest(BaseModel):
+    command: str
+
+
+class FrequencyRequest(BaseModel):
+    frequency_hz: int
+
+
+def get_controller(settings: Settings = Depends(Settings)) -> FT897Controller:
+    return FT897Controller(
+        CATConfig(
+            port=settings.serial_port,
+            baudrate=settings.baudrate,
+            timeout=settings.serial_timeout,
+            simulate=settings.simulate_radio,
+        )
+    )
+
+
+def get_audio_streamer(settings: Settings = Depends(Settings)) -> AudioStreamer:
+    return AudioStreamer(
+        AudioConfig(
+            samplerate=settings.audio_samplerate,
+            channels=settings.audio_channels,
+            blocksize=settings.audio_blocksize,
+            enabled=settings.audio_enabled,
+            device=settings.audio_device,
+        )
+    )
+
+
+app = FastAPI(title="FT-897 Remote Control", version="1.0.0")
+
+BASE_DIR = Path(__file__).resolve().parent
+TEMPLATES = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    return TEMPLATES.TemplateResponse("index.html", {"request": request})
+
+
+@app.post("/api/command", response_class=JSONResponse)
+async def send_command(data: CommandRequest, controller: FT897Controller = Depends(get_controller)) -> JSONResponse:
+    try:
+        response = controller.send_raw_command(data.command)
+    except Exception as exc:  # pragma: no cover - depends on hardware
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return JSONResponse({"command": data.command, "response": response})
+
+
+@app.post("/api/frequency", response_class=JSONResponse)
+async def set_frequency(data: FrequencyRequest, controller: FT897Controller = Depends(get_controller)) -> JSONResponse:
+    try:
+        controller.set_vfo_a_frequency(data.frequency_hz)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return JSONResponse({"frequency_hz": data.frequency_hz})
+
+
+@app.get("/api/frequency", response_class=JSONResponse)
+async def get_frequency(controller: FT897Controller = Depends(get_controller)) -> JSONResponse:
+    try:
+        frequency = controller.get_vfo_a_frequency()
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    if frequency is None:
+        raise HTTPException(status_code=502, detail="No response from radio")
+    return JSONResponse({"frequency_hz": frequency})
+
+
+@app.post("/api/ptt", response_class=JSONResponse)
+async def set_ptt(active: bool = Form(...), controller: FT897Controller = Depends(get_controller)) -> JSONResponse:
+    try:
+        controller.set_ptt(active)
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return JSONResponse({"ptt": active})
+
+
+@app.get("/api/ptt", response_class=JSONResponse)
+async def get_ptt(controller: FT897Controller = Depends(get_controller)) -> JSONResponse:
+    try:
+        status = controller.get_ptt_status()
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    if status is None:
+        raise HTTPException(status_code=502, detail="No response from radio")
+    return JSONResponse({"ptt": status})
+
+
+@app.get("/audio/stream")
+async def audio_stream(streamer: AudioStreamer = Depends(get_audio_streamer)) -> StreamingResponse:
+    try:
+        generator = streamer.audio_generator()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return StreamingResponse(generator, media_type="audio/wav")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    logging.basicConfig(level=logging.INFO)
+    LOGGER.info("FT-897 remote control server starting up")
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    LOGGER.info("FT-897 remote control server shutting down")

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,97 @@
+:root {
+  color-scheme: only dark;
+  font-size: 18px;
+}
+
+body {
+  margin: 0;
+  font-family: "Arial", "Helvetica", sans-serif;
+  background-color: #000;
+  color: #fff;
+  line-height: 1.6;
+}
+
+main {
+  padding: 2rem;
+}
+
+h1,
+ h2 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+button,
+ input,
+ select,
+ textarea {
+  font-size: 1.2rem;
+  padding: 0.75rem;
+  border: 2px solid #fff;
+  background-color: #222;
+  color: #fff;
+  border-radius: 0.5rem;
+}
+
+button:hover,
+ button:focus,
+ input:focus,
+ select:focus,
+ textarea:focus {
+  outline: 3px solid #ffcc00;
+  outline-offset: 2px;
+}
+
+button {
+  cursor: pointer;
+  display: inline-block;
+  margin-top: 0.5rem;
+}
+
+.section {
+  margin-bottom: 2rem;
+  border: 2px solid #444;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  background-color: #111;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.alert {
+  padding: 1rem;
+  background-color: #333;
+  border-left: 4px solid #ffcc00;
+  margin-bottom: 1rem;
+}
+
+#command-response {
+  margin-top: 1rem;
+  background-color: #0a0a0a;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #333;
+}
+
+a {
+  color: #ffcc00;
+}
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  background: #ffcc00;
+  color: #000;
+  padding: 0.75rem 1rem;
+  z-index: 100;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 0;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FT-897 Dálkové ovládání</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Přeskočit na hlavní obsah</a>
+    <main id="main" tabindex="-1">
+      <header class="section" aria-labelledby="title">
+        <h1 id="title">FT-897 Dálkové ovládání</h1>
+        <p>
+          Tato webová aplikace umožňuje vzdáleně ovládat radiostanici Yaesu
+          FT-897 prostřednictvím CAT příkazů a zároveň poskytuje stream zvuku z
+          připojené stanice.
+        </p>
+      </header>
+
+      <section class="section" aria-labelledby="status-heading">
+        <h2 id="status-heading">Stav radiostanice</h2>
+        <div class="alert" role="status" aria-live="polite">
+          <p>
+            <strong>Aktuální frekvence:</strong>
+            <span id="frequency">Neznámá</span>
+          </p>
+          <p>
+            <strong>PTT:</strong>
+            <span id="ptt-status">Neznámé</span>
+          </p>
+          <button id="refresh-status" type="button">Aktualizovat stav</button>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="frequency-heading">
+        <h2 id="frequency-heading">Nastavení frekvence</h2>
+        <form id="frequency-form">
+          <label for="frequency-input">Frekvence v Hz</label>
+          <input
+            id="frequency-input"
+            name="frequency_hz"
+            type="number"
+            inputmode="numeric"
+            min="100000"
+            max="500000000"
+            required
+            aria-describedby="frequency-help"
+          />
+          <p id="frequency-help">
+            Zadejte frekvenci ve formátu Hz (například 14074000 pro 14.074 MHz).
+          </p>
+          <button type="submit">Odeslat</button>
+        </form>
+      </section>
+
+      <section class="section" aria-labelledby="ptt-heading">
+        <h2 id="ptt-heading">Ovládání PTT</h2>
+        <div role="group" aria-labelledby="ptt-heading">
+          <button id="ptt-on" type="button">Vysílat</button>
+          <button id="ptt-off" type="button">Přijímat</button>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="command-heading">
+        <h2 id="command-heading">Vlastní CAT příkaz</h2>
+        <form id="command-form">
+          <label for="command-input">CAT příkaz</label>
+          <input id="command-input" name="command" type="text" required />
+          <button type="submit">Odeslat příkaz</button>
+        </form>
+        <div id="command-response" aria-live="polite"></div>
+      </section>
+
+      <section class="section" aria-labelledby="audio-heading">
+        <h2 id="audio-heading">Audio stream</h2>
+        <p>
+          Níže můžete poslouchat aktuální zvuk ze stanice. Stream je dostupný ve
+          formátu WAV a lze jej přehrávat v běžných prohlížečích.
+        </p>
+        <audio controls preload="none" aria-label="Audio stream FT-897">
+          <source src="/audio/stream" type="audio/wav" />
+          Váš prohlížeč nepodporuje přehrávání audio streamu.
+        </audio>
+      </section>
+    </main>
+
+    <script>
+      async function fetchJSON(url, options = {}) {
+        const response = await fetch(url, options);
+        if (!response.ok) {
+          const error = await response.json().catch(() => ({}));
+          throw new Error(error.detail || response.statusText);
+        }
+        return response.json();
+      }
+
+      async function refreshStatus() {
+        try {
+          const freqData = await fetchJSON("/api/frequency");
+          const pttData = await fetchJSON("/api/ptt");
+          document.getElementById("frequency").textContent =
+            freqData.frequency_hz.toLocaleString("cs-CZ");
+          document.getElementById("ptt-status").textContent = pttData.ptt
+            ? "Vysílá"
+            : "Přijímá";
+        } catch (error) {
+          document.getElementById("frequency").textContent = "Chyba";
+          document.getElementById("ptt-status").textContent = "Chyba";
+          console.error(error);
+        }
+      }
+
+      document
+        .getElementById("refresh-status")
+        .addEventListener("click", refreshStatus);
+
+      document
+        .getElementById("frequency-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const formData = new FormData(event.target);
+          const frequency_hz = Number(formData.get("frequency_hz"));
+          try {
+            await fetchJSON("/api/frequency", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ frequency_hz }),
+            });
+            refreshStatus();
+          } catch (error) {
+            alert(`Nepodařilo se nastavit frekvenci: ${error.message}`);
+          }
+        });
+
+      document
+        .getElementById("command-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const formData = new FormData(event.target);
+          const command = formData.get("command");
+          try {
+            const result = await fetchJSON("/api/command", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ command }),
+            });
+            document.getElementById(
+              "command-response"
+            ).textContent = `Odpověď: ${result.response}`;
+          } catch (error) {
+            document.getElementById("command-response").textContent =
+              "Chyba: " + error.message;
+          }
+        });
+
+      document.getElementById("ptt-on").addEventListener("click", async () => {
+        try {
+          await fetchJSON("/api/ptt", {
+            method: "POST",
+            body: new URLSearchParams({ active: "true" }),
+          });
+          refreshStatus();
+        } catch (error) {
+          alert(`Nepodařilo se aktivovat PTT: ${error.message}`);
+        }
+      });
+
+      document.getElementById("ptt-off").addEventListener("click", async () => {
+        try {
+          await fetchJSON("/api/ptt", {
+            method: "POST",
+            body: new URLSearchParams({ active: "false" }),
+          });
+          refreshStatus();
+        } catch (error) {
+          alert(`Nepodařilo se deaktivovat PTT: ${error.message}`);
+        }
+      });
+
+      refreshStatus();
+    </script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+pyserial
+jinja2
+python-multipart
+sounddevice


### PR DESCRIPTION
## Summary
- implement a FastAPI-based backend with CAT helpers for the Yaesu FT-897 and optional audio streaming
- add an accessible high-contrast frontend for common CAT actions and live audio playback
- document configuration options and project setup requirements

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cfbdeb88788321ae13473cee8bc75b